### PR TITLE
Update sonar-l10n-pt properties to reflect the current state

### DIFF
--- a/_posts/2017-06-07-l10npt.markdown
+++ b/_posts/2017-06-07-l10npt.markdown
@@ -10,8 +10,8 @@ download_description: Support for SonarQube 6.4
 download_date: 2017-06-07
 license: GNU LGPL 3
 developers: Marcos Oliveira Junqueira,Mario Celso Teixeira,Felipe Zorzo
-sonarqube_version: 6.7-7.3
-category: localization
+sonarqube_version: 6.4
+category: deprecated
 description: Language Pack for Portuguese
 details: 
 seo: 


### PR DESCRIPTION
I was the mantainer of sonar-l10n-pt, as can be seen in the organization_url property, and this plugin was deprecated years ago. I've updated the properties to reflect its state.